### PR TITLE
Fix `type` prop `type`

### DIFF
--- a/ampersand-array-checkbox-view.js
+++ b/ampersand-array-checkbox-view.js
@@ -70,7 +70,7 @@ module.exports = View.extend({
         maxLength: ['number', true, 10],
         template: ['string', true, defaultTemplate],
         fieldTemplate: ['string', true, defaultFieldTemplate],
-        type: ['text', true, 'text']
+        type: ['string', true, 'text']
     },
     session: {
         shouldValidate: ['boolean', true, false],


### PR DESCRIPTION
After updating to Ampersand-State `v4.8.0` a `TypeError` is thrown: `Invalid data type of`text`for`type`property. Use one of the default types or define your own`

Change the `type` prop's `type` to a valid type. (`text` -> `string`)
